### PR TITLE
remove any .gitignore file in reports/htmlcov so new files get added

### DIFF
--- a/.github/scripts/move_reports_to_gh_pages.sh
+++ b/.github/scripts/move_reports_to_gh_pages.sh
@@ -3,6 +3,11 @@
 # Get reference to project root directory
 PROJECT_ROOT=$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")")
 
+# Remove existing directory, /tmp/readinglist, and all its contents (if it exists)
+if [ -d "/tmp/readinglist" ]; then
+  rm -rf /tmp/readinglist
+fi
+
 # Clone the gh-page branch for repo with our pages source into a new directory under /tmp
 git clone --branch gh-pages --single-branch https://x-access-token:${GITHUB_TOKEN}@github.com/dandoug/readinglist.git /tmp/readinglist
 
@@ -16,6 +21,11 @@ REPORTS_TO_MOVE=("coverage.xml" "pylint.report.txt" "htmlcov" "coverage.json" "p
 for REPORT in "${REPORTS_TO_MOVE[@]}"; do
   mv "$PROJECT_ROOT/$REPORT" /tmp/readinglist/reports/
 done
+
+# Don't let htmlcov keep a .gitignore file, prevents adding new coverage files
+if [ -f "/tmp/readinglist/reports/htmlcov/.gitignore" ]; then
+  rm /tmp/readinglist/reports/htmlcov/.gitignore
+fi
 
 # Stage and commit all the modified or added files in the /tmp/readinglist directory
 (


### PR DESCRIPTION
problem was that a `.gitignore` file was getting generated in the `htmlcov` directory with the reports and was keeping any new files from being added.  Modified `.github/scripts/move_reports_to_gh_pages.sh` to remove the `.gitignore` file during the move process.

Verified locally that new files in the report were getting staged.